### PR TITLE
Changes in output and formatting, allow regions to be optionally specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,34 @@ Requires boto.  Tested on python 2.7.
 
 Will use roles or environment variables to authenticate itself to the EC2 API.
 
-Negative numbers indicate excess/unused RIs provisioned for that instance type in that AZ
+For each instance type, in each availability zone, in each selected region, 
+RICounter provides the number of running instances, the number of matching
+reservations, and the difference between the two.
 
-Positive numbers indicate un-reserved instances of that type in that AZ
+Negative differences indicate unused reservations.
+Positive differences indicate instances not matching a reservation.
 
-Usage: ./RICounter.py
+usage: RICounter.py [-h] [--region REGIONS]
 
+optional arguments:
+  -h, --help        show this help message and exit
+  --region REGIONS  specify a region (default is all standard regions)
 Sample output:
 
-    us-east-1b - c3.xlarge  0
-    us-east-1b - m1.small   1
-    us-east-1b - m3.large   1
-    us-east-1b - m3.medium  2
-    us-east-1c - c1.xlarge  0
-    us-east-1c - c3.2xlarge 0
-    us-east-1c - c3.large   2
-    us-east-1c - m1.large   1
-    us-east-1c - m1.small   3
-    us-east-1c - m1.xlarge  1
-    us-east-1c - m3.large   2
-    us-east-1c - m3.medium  2
-    us-east-1c - m3.xlarge  0
-    us-east-1c - t1.micro   2
-    us-east-1d - m1.xlarge  1
-    us-east-1e - t1.micro   1
-    us-west-1c - t1.micro   1
+Instance    AZ      Run Reserve Diff
+c3.2xlarge  us-east-1b  3   3   0
+c3.2xlarge  us-east-1d  2   2   0
+c4.large    us-east-1b  2   2   0
+c4.large    us-east-1d  2   2   0
+c4.large    us-east-1e  2   2   0
+m1.large    us-east-1b  3   4   -1
+c3.xlarge   eu-west-1b  3   3   0
+c3.xlarge   eu-west-1c  3   3   0
+m3.2xlarge  eu-west-1b  14  13  1
+m3.2xlarge  eu-west-1c  13  13  0
+c3.large    us-west-2a  1   1   0
+c3.large    us-west-2b  1   1   0
+c3.large    us-west-2c  1   1   0
+c3.xlarge   us-west-2a  3   3   0
+c3.xlarge   us-west-2b  3   3   0
+c3.xlarge   us-west-2c  3   3   0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ optional arguments:
   --region REGIONS  specify a region (default is all standard regions)
 Sample output:
 
-`
+```
 Instance    AZ      Run Reserve Diff
 c3.2xlarge  us-east-1b  3   3   0
 c3.2xlarge  us-east-1d  2   2   0
@@ -37,4 +37,4 @@ c3.large    us-west-2c  1   1   0
 c3.xlarge   us-west-2a  3   3   0
 c3.xlarge   us-west-2b  3   3   0
 c3.xlarge   us-west-2c  3   3   0
-`
+```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ optional arguments:
   --region REGIONS  specify a region (default is all standard regions)
 Sample output:
 
+`
 Instance    AZ      Run Reserve Diff
 c3.2xlarge  us-east-1b  3   3   0
 c3.2xlarge  us-east-1d  2   2   0
@@ -36,3 +37,4 @@ c3.large    us-west-2c  1   1   0
 c3.xlarge   us-west-2a  3   3   0
 c3.xlarge   us-west-2b  3   3   0
 c3.xlarge   us-west-2c  3   3   0
+`

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ For each instance type, in each availability zone, in each selected region,
 RICounter provides the number of running instances, the number of matching
 reservations, and the difference between the two.
 
-Negative differences indicate unused reservations.
-Positive differences indicate instances not matching a reservation.
+Negative differences indicate unused reservations, whereas positive differences 
+indicate instances not matching a reservation.
 
 usage: RICounter.py [-h] [--region REGIONS]
 

--- a/RICounter.py
+++ b/RICounter.py
@@ -7,35 +7,22 @@ negative balances indicate excess reserved instances
 positive balances indicate instances that are not falling under RIs
 """
 
-from collections import Counter;
-from os import getenv;
-import boto.ec2;
-import boto.rds;
+from collections import Counter
 
-DISABLED_REGIONS = ['cn-north-1', 'us-gov-west-1'];
+import boto.ec2
 
-regions = boto.ec2.regions();
+DISABLED_REGIONS = ['cn-north-1', 'us-gov-west-1']
 
-for region in regions:
-	if region.name in DISABLED_REGIONS:
-		continue;
+for region in [ r for r in boto.ec2.regions() if r.name not in DISABLED_REGIONS ]:
+	ec2 = region.connect()
 
-	try:
-		ec2 = region.connect();
+	reservations = ec2.get_all_reservations(filters={'instance-state-name':'running'})
+	instances = [i.instance_type + ' - ' + i.placement for r in reservations for i in r.instances]
 
-		reservations = ec2.get_all_reservations();
-	except Exception as e:
-		logging.warning("Could not get instance reservations for region: " + region.name + " (" + e.message + ")");
-		continue;
+	instance_counter = Counter(instances)
 
-
-	instances = [i.placement + ' - ' + i.instance_type for r in reservations for i in r.instances if i.state == 'running'];
-
-	instance_counter = Counter(instances);
-
-	for ri in ec2.get_all_reserved_instances():
-		if ri.state == 'active':
-			instance_counter.subtract({ri.availability_zone + ' - ' + ri.instance_type: ri.instance_count});
+	for ri in ec2.get_all_reserved_instances(filters={'state' : 'active'}):
+		instance_counter.subtract({ri.instance_type + ' - ' + ri.availability_zone : ri.instance_count})
 
 	for key in sorted(instance_counter.keys()):
-		print "%s\t%d" % (key, instance_counter[key]);
+		print "%s\t%d" % (key, instance_counter[key])

--- a/RICounter.py
+++ b/RICounter.py
@@ -8,21 +8,35 @@ positive balances indicate instances that are not falling under RIs
 """
 
 from collections import Counter
+from collections import defaultdict
 
 import boto.ec2
 
 DISABLED_REGIONS = ['cn-north-1', 'us-gov-west-1']
+instance_filters = {
+	'instance-state-name': 'running'
+}
+reservation_filters = {
+	'state': 'active'
+}
 
+print "Instance\tAZ\t\tRun\tReserve\tDiff"
 for region in [ r for r in boto.ec2.regions() if r.name not in DISABLED_REGIONS ]:
 	ec2 = region.connect()
 
-	reservations = ec2.get_all_reservations(filters={'instance-state-name':'running'})
-	instances = [i.instance_type + ' - ' + i.placement for r in reservations for i in r.instances]
+	running = ec2.get_all_reservations(filters=instance_filters)
+	running_instances = [i.instance_type + "\t" + i.placement for r in running for i in r.instances]
+	running_instance_counter = Counter(running_instances)
 
-	instance_counter = Counter(instances)
+	reserved_instances = defaultdict(int)
+	for ri in ec2.get_all_reserved_instances(filters=reservation_filters):
+		reserved_instances[ri.instance_type + "\t" + ri.availability_zone] += ri.instance_count
 
-	for ri in ec2.get_all_reserved_instances(filters={'state' : 'active'}):
-		instance_counter.subtract({ri.instance_type + ' - ' + ri.availability_zone : ri.instance_count})
+	keys = set(reserved_instances.keys() + running_instance_counter.keys())
+	
+	if len(keys) == 0:
+		continue
 
-	for key in sorted(instance_counter.keys()):
-		print "%s\t%d" % (key, instance_counter[key])
+	for key in sorted(keys):
+		print "%s\t%d\t%d\t%d" % (key, running_instance_counter[key], reserved_instances[key], 
+			running_instance_counter[key] -  reserved_instances[key])

--- a/RICounter.py
+++ b/RICounter.py
@@ -8,7 +8,6 @@ positive balances indicate instances that are not falling under RIs
 """
 import argparse
 
-from collections import Counter
 from collections import defaultdict
 
 import boto.ec2
@@ -36,18 +35,20 @@ else:
 for region in regions:
 	ec2 = region.connect()
 
+	running_instances = defaultdict(int)
 	running = ec2.get_all_reservations(filters=instance_filters)
-	running_instances = [i.instance_type + "\t" + i.placement for r in running for i in r.instances]
-	running_instance_counter = Counter(running_instances)
+	for r in running:
+		for i in r.instances:
+			running_instances[i.instance_type + "\t" + i.placement] += 1
 
 	reserved_instances = defaultdict(int)
 	for ri in ec2.get_all_reserved_instances(filters=reservation_filters):
 		reserved_instances[ri.instance_type + "\t" + ri.availability_zone] += ri.instance_count
 
-	keys = set(reserved_instances.keys() + running_instance_counter.keys())
+	keys = set(reserved_instances.keys() + running_instances.keys())
 	if len(keys) == 0:
 		continue
 
 	for key in sorted(keys):
-		print "%s\t%d\t%d\t%d" % (key, running_instance_counter[key], reserved_instances[key], 
-			running_instance_counter[key] -  reserved_instances[key])
+		print "%s\t%d\t%d\t%d" % (key, running_instances[key], reserved_instances[key], 
+			running_instances[key] - reserved_instances[key])


### PR DESCRIPTION
Hey there-

I started with your handy script, but I made a few changes to make it easier for me to use in my (relatively large) environment.  These included changing the output to show running, reserved, and the difference instead of just the difference, as well as adding a '--region' flag that allows a user to optionally report on one or more specific regions.

I also changed the ordering to be instance type first, then region, so that it's easier to spot situations where I can modify existing reservations to better meet current needs.

I realize that this is almost a rewrite at this point, so it might not fit your needs, but I wanted to share it with you.
